### PR TITLE
#18 [Chore] output 디렉토리 생성 경로 불일치 오류 수정

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-cd ../
-mkdir output
-cp -R ./QOn/* ./output
-cp -R ./output ./QOn/
+# 항상 저장소 루트에서 실행
+mkdir -p output
+cp -R ./Q-On/* ./output/

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 # 항상 저장소 루트에서 실행
 mkdir -p output
-cp -R ./QOn/* ./output/
+# 레포 루트 전체를 output으로 복사
+cp -R ./* ./output/
+echo "./output 폴더 생성 완료"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # 항상 저장소 루트에서 실행
 mkdir -p output
-cp -R ./Q-On/* ./output/
+cp -R ./QON/* ./output/

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # 항상 저장소 루트에서 실행
 mkdir -p output
-cp -R ./QON/* ./output/
+cp -R ./QOn/* ./output/


### PR DESCRIPTION
<!-- PR 제목 #브랜치넘버 [컨벤션] 제목
예시) #이슈번호 [Feat] 사용자 로그인 기능 구현 -->

![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/S-Project-Jin-Han/Q-On?utm_source=oss&utm_medium=github&utm_campaign=S-Project-Jin-Han%2FQ-On&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)

# 주요 작업 내용 (전체 요약)
build.sh 스크립트 수정
- 불필요한 cd ../ 및 자기복사(cp -R ./output ./Q-On/) 제거
- Q-On 디렉토리 내 빌드 결과물을 output/으로 정상 복사되도록 개선

<!-- 이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요. -->
<!-- 도입 이유 명확히 설명해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 경로·디렉터리 처리 개선으로 빌드 실패 가능성을 낮췄습니다.

- **문서**
  - 스크립트가 항상 저장소 루트에서 실행된다는 주석을 추가해 동작을 명확히 했습니다.

- **Chores**
  - 디렉터리 생성 로직을 안전하게 변경해 중복 실행에 대응했습니다.
  - 복사 흐름의 대상 경로 정리 및 역복사 제거로 복사 과정을 단순화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->